### PR TITLE
目次あたり修正

### DIFF
--- a/src/app/blog/[round]/[index]/components/blog-card-client.tsx
+++ b/src/app/blog/[round]/[index]/components/blog-card-client.tsx
@@ -5,11 +5,6 @@ import BlogCardImpl from "../../../blog-card-impl";
 
 import { useEffect, useState } from "react";
 
-/**
- * Return a visual link component to the specified blog post.
- * @example <BlogCard path={"61/01"} />
- * @param path - Specify the blog post to display. `("<round>/<index>")`
- */
 export default function BlogCardClient({ round, index }: { round: string; index: string }) {
     const [blog, setBlog] = useState<BlogMetadata | undefined>(undefined);
     useEffect(() => {

--- a/src/app/blog/[round]/[index]/components/buttons.tsx
+++ b/src/app/blog/[round]/[index]/components/buttons.tsx
@@ -27,7 +27,7 @@ export function ToTop() {
     return (
         <div
             className={`fixed bottom-[50px] left-[calc(100lvw-80px-clamp(30px,7svw,60px))] z-1 size-[clamp(30px,7svw,60px)] cursor-pointer
-                rounded-full bg-pri-red transition not-b:hidden hover:brightness-120 ${hidden ? "pointer-events-none opacity-0" : ""}`}
+                rounded-full bg-pri-red transition hover:brightness-120 max-b:hidden ${hidden ? "pointer-events-none opacity-0" : ""}`}
             onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
         >
             <ArrowUp className="size-full" />

--- a/src/app/blog/[round]/[index]/components/recommended-posts.tsx
+++ b/src/app/blog/[round]/[index]/components/recommended-posts.tsx
@@ -43,7 +43,7 @@ export default function RecommendedPosts({
                     <p className={"ml-[5dvw] text-xl/normal font-medium first-letter:text-pri-red b:ml-[-10px]"}>
                         ＞ こちらの記事もおすすめ
                     </p>
-                    <div className={"mt-[30px] flex justify-center gap-4 md:justify-between max-b:md:justify-evenly"}>
+                    <div className={"mt-[30px] flex justify-center gap-4 min-[820px]:justify-evenly b:justify-between"}>
                         <div>
                             <BlogCardClient round={recommendedPaths[0].round} index={recommendedPaths[0].index} />
                         </div>

--- a/src/app/blog/[round]/[index]/components/table.tsx
+++ b/src/app/blog/[round]/[index]/components/table.tsx
@@ -31,8 +31,8 @@ export default function Table({ toc }: { toc: { name: string; id: string }[] }) 
     }, [toc]);
 
     return (
-        <div className={"rounded-[20px] border-3 border-[#dedede] p-[20px] text-pri-black"}>
-            <div className="mb-[5px] text-[19px]/normal font-medium">目次</div>
+        <section className={"rounded-[20px] border-3 border-[#dedede] p-[20px] text-pri-black"}>
+            <h2 className="mb-[5px] text-[19px]/normal font-medium">目次</h2>
             <ul>
                 {toc.map((item) => (
                     <a href={`#${item.id}`} key={item.id}>
@@ -45,6 +45,6 @@ export default function Table({ toc }: { toc: { name: string; id: string }[] }) 
                     </a>
                 ))}
             </ul>
-        </div>
+        </section>
     );
 }

--- a/src/app/blog/[round]/[index]/page.tsx
+++ b/src/app/blog/[round]/[index]/page.tsx
@@ -44,7 +44,7 @@ function DownloadButton({ url, filename, filesize }: { url: string; filename: st
         <Link
             download
             href={url}
-            className={`mx-auto mt-[20px] flex h-12.5 w-max max-w-full items-center rounded-[12px] border-3 border-[#dedede] bg-[#fefefe]
+            className={`mx-auto mt-[20px] flex h-12.5 w-max max-w-19/20 items-center rounded-[12px] border-3 border-[#dedede] bg-[#fefefe]
                 text-sm/normal text-pri-black transition-[box-shadow] duration-200 hover:[box-shadow:_#0b0e0f20_0px_0px_5px] b:h-15
                 b:max-w-4/5 b:text-lg/normal`}
         >
@@ -73,7 +73,7 @@ export default async function Page({ params }: { params: Promise<{ round: string
     return (
         <>
             <ToTop />
-            <Image src={thumbnail} alt="thumbnail" className={"h-[30svh] w-[100dvw] object-cover object-center"} />
+            <Image src={thumbnail} alt="thumbnail" className={"h-[30svh] w-dvw object-cover object-center"} />
             <h1
                 className={`mx-auto mt-[25px] max-w-[90svw] border-b-2 border-pri-black text-start text-[1.75rem]/normal font-medium text-pri-red
                     b:mt-[30px] b:px-[100px] b:text-center b:text-[2.5rem]/normal`}
@@ -92,10 +92,12 @@ export default async function Page({ params }: { params: Promise<{ round: string
                     </div>
                 </div>
                 <div
-                    className={`sticky top-[104px] float-right clear-right mt-[80px] mr-[8dvw] max-h-[calc(100dvh-80px)] w-[20dvw] min-w-[255px]
+                    className={`sticky top-[64px] float-right clear-right mt-[80px] mr-[7dvw] max-h-[calc(100dvh-64px)] w-[20dvw] min-w-[255px]
                         overflow-y-auto leading-[1.5] text-pri-black max-b:hidden`}
                 >
-                    <Table toc={toc} />
+                    <div className={"mt-[40px] mr-[1dvw]"}>
+                        <Table toc={toc} />
+                    </div>
                     <div className={"mt-[30px] flex w-full items-center justify-between"}>
                         <Link href={prevLink} className={"flex items-center text-left text-[18px] hover:opacity-80"}>
                             <div className="text-pri-red select-none">＜&nbsp;</div>
@@ -125,21 +127,20 @@ export default async function Page({ params }: { params: Promise<{ round: string
                 >
                     <div>{description}</div>
                     <hr className={"mx-5 mt-10 border-t-2 border-pri-red max-b:hidden"} />
-                    <div className={"mt-[35px] w-19/20 b:hidden"}>
+                    <div className={"mx-auto mt-[35px] w-19/20 b:hidden"}>
                         <Table toc={toc} />
                     </div>
                     <div>{content}</div>
                 </div>
             </article>
-            <nav className={"mx-auto my-[40px] w-[90svw] b:mt-[60px] b:mb-[50px] b:w-[max(750px,56dvw)]"}>
+            <nav className={"mx-auto my-[40px] w-[90dvw] b:mt-[60px] b:mb-[50px] b:w-[max(750px,56dvw)]"}>
                 <div
-                    id="tolist"
                     className={
                         "flex items-center justify-center text-xl/normal font-medium text-pri-black transition-opacity hover:opacity-80 b:hidden"
                     }
                 >
                     <Link href="/2025/blog" className={"flex items-center justify-center gap-3 text-[18px]"}>
-                        <Grid className="h-[28px] w-[28px]" />
+                        <Grid className="size-[28px]" />
                         記事一覧へ
                     </Link>
                 </div>


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

どうでもいいところと結構重要かもしれないところの修正。

以下重要かもしれないところ
**page.tsx**
- サイドバー部分が画面からあふれるときのスクロールに関して、 height 修正。
- ↑ 上端も変なので修正し、ヘッダーの高さ分以外を margin-top に設定。
- ↑ スクロールバーが border と重なるのが気持ち悪いので 1dvw 分を margin-right に。
- スマホ版目次を左寄せから中央に。

<!-- I want to review in Japanese. -->
